### PR TITLE
Make command letter spacing consistent

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,7 @@ body {
     background: #211D1B;
     font-family: cursor, monospace;
     overflow-x: hidden;
+    letter-spacing: 0.05em;
   }
   ::selection {
     color: #211830;
@@ -82,7 +83,6 @@ body {
     overflow: hidden;
     white-space: nowrap;
     margin: 0;
-    letter-spacing: 0.05em;
     animation: typing 0.5s steps(30, end);
   }
   .no-animation {


### PR DESCRIPTION
In old version, the textarea text has text-spacing = 0em, while all other text has text-spacing = 0.05em. By making these two a consistent 0.05em, then past commands have the same look as current commands.

Also, I noticed this bc I'm making my own version of a terminal portfolio website using yours as a template. This is a bug I found that I thought you might appreciate me fixing! If you ever want to use my updated version (e.g., added swappable themes), when you're more than welcome to clone it. website link --> lundeen06.github.io; repo --> https://github.com/lundeen06/lundeen06.github.io

-Lundeen